### PR TITLE
Fix PUT handler

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -4,7 +4,7 @@ require('make-promises-safe');
 const hapi = require('hapi');
 const mongoose = require('mongoose');
 mongoose.Promise = global.Promise;
-mongoose.connect('mongodb://localhost/forest-example', { useMongoClient: true });
+mongoose.connect('mongodb://localhost/forest-example');
 
 const server = new hapi.server({ port: 8080 });
 

--- a/handlers/put.js
+++ b/handlers/put.js
@@ -12,7 +12,9 @@ module.exports = (route, options) => {
     req.payload[options.idKey] = hu.getId(options, req);
 
     const { overwrite, upsert } = options;
-    const query = Model.update(condition, req.payload, { overwrite, upsert }).lean();
+    const query = overwrite
+      ? Model.replaceOne(condition, req.payload, { upsert })
+      : Model.updateOne(condition, req.payload, { upsert });
 
     if (options.preQuery) options.preQuery(query); // query extension point
     let res = await query.exec().catch(hu.handleError);

--- a/handlers/put.js
+++ b/handlers/put.js
@@ -11,10 +11,8 @@ module.exports = (route, options) => {
     const condition = hu.getIdQuery(options, req);
     req.payload[options.idKey] = hu.getId(options, req);
 
-    const query = Model.updateOne(condition, req.payload, {
-      overwrite: options.overwrite,
-      upsert: options.upsert,
-    }).lean();
+    const { overwrite, upsert } = options;
+    const query = Model.update(condition, req.payload, { overwrite, upsert }).lean();
 
     if (options.preQuery) options.preQuery(query); // query extension point
     let res = await query.exec().catch(hu.handleError);

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "inert": "^5.0.1",
     "lint-staged": "^6.0.0",
     "make-promises-safe": "^1.1.0",
-    "mongoose": "^4.7.2",
+    "mongoose": "^5.4.8",
     "nodemon": "^1.13.3",
     "nyc": "^11.3.0",
     "pre-commit": "^1.1.3",

--- a/test/get-all-handler-test.js
+++ b/test/get-all-handler-test.js
@@ -2,7 +2,7 @@ const test = require('ava');
 // TODO: separate connection for each test
 const mongoose = require('mongoose');
 mongoose.Promise = global.Promise;
-mongoose.connect('mongodb://localhost/forest-test', { useMongoClient: true });
+mongoose.connect('mongodb://localhost/forest-test');
 const createServer = require('./helpers/createServer.js');
 const CatModel = require('./fixtures/test-cat-model');
 

--- a/test/get-one-handler-test.js
+++ b/test/get-one-handler-test.js
@@ -2,7 +2,7 @@ const test = require('ava');
 // TODO: separate connection for each test
 const mongoose = require('mongoose');
 mongoose.Promise = global.Promise;
-mongoose.connect('mongodb://localhost/forest-test', { useMongoClient: true });
+mongoose.connect('mongodb://localhost/forest-test');
 const createServer = require('./helpers/createServer.js');
 const CatModel = require('./fixtures/test-cat-model');
 

--- a/test/patch-handler-test.js
+++ b/test/patch-handler-test.js
@@ -2,7 +2,7 @@ const test = require('ava');
 // TODO: separate connection for each test
 const mongoose = require('mongoose');
 mongoose.Promise = global.Promise;
-mongoose.connect('mongodb://localhost/forest-test', { useMongoClient: true });
+mongoose.connect('mongodb://localhost/forest-test');
 const createServer = require('./helpers/createServer.js');
 const CatModel = require('./fixtures/test-cat-model');
 const CatModelTimestamps = require('./fixtures/test-cat-model-with-timestamp.js');

--- a/test/post-handler-test.js
+++ b/test/post-handler-test.js
@@ -2,7 +2,7 @@ const test = require('ava');
 // TODO: separate connection for each test
 const mongoose = require('mongoose');
 mongoose.Promise = global.Promise;
-mongoose.connect('mongodb://localhost/forest-test', { useMongoClient: true });
+mongoose.connect('mongodb://localhost/forest-test');
 const createServer = require('./helpers/createServer.js');
 const CatModel = require('./fixtures/test-cat-model');
 

--- a/test/put-handler-test.js
+++ b/test/put-handler-test.js
@@ -31,6 +31,8 @@ test('create a new database entry', async t => {
 
   const res = await put('PutCat1', { fromTest: 'put' });
   t.is(res.statusCode, 201, 'Status code is 201');
+  t.is(res.result.name, 'PutCat1', 'Correct name saved');
+  t.is(res.result.fromTest, 'put', 'Correct data saved');
 
   const dbEntry = await CatModel.findOne({ name: 'PutCat1' }).lean();
   t.true(dbEntry !== null, 'db entry exists');
@@ -55,6 +57,8 @@ test('create a new database entry from model with timestamps', async t => {
 
   const res = await put('PutCatTimestamp', { fromTest: 'put', meta: { age: 2 } });
   t.is(res.statusCode, 201, 'Status code is 201');
+  t.is(res.result.name, 'PutCatTimestamp', 'response has correct name');
+  t.is(res.result.meta.age, 2, 'response has correct meta');
 
   const dbEntry = await CatModelTimestamps.findOne({ name: 'PutCatTimestamp' }).lean();
   t.true(dbEntry !== null, 'db entry exists');
@@ -94,6 +98,7 @@ test('update an existing database entry', async t => {
 
   const res2 = await put('PutCat2', { fromTest: 'put', meta: { age: 1 } });
   t.is(res2.statusCode, 200, 'Status code is 200');
+  t.is(res2.result.meta.age, 1, 'entry the updated age');
 
   const updatedDbEntry = await CatModel.findOne({ name: 'PutCat2' }).lean();
   t.true(updatedDbEntry !== null, 'db entry exists');

--- a/test/put-handler-test.js
+++ b/test/put-handler-test.js
@@ -2,7 +2,7 @@ const test = require('ava');
 // TODO: separate connection for each test
 const mongoose = require('mongoose');
 mongoose.Promise = global.Promise;
-mongoose.connect('mongodb://localhost/forest-test', { useMongoClient: true });
+mongoose.connect('mongodb://localhost/forest-test');
 const createServer = require('./helpers/createServer.js');
 const CatModel = require('./fixtures/test-cat-model');
 const CatModelTimestamps = require('./fixtures/test-cat-model-with-timestamp.js');

--- a/test/put-handler-test.js
+++ b/test/put-handler-test.js
@@ -53,12 +53,13 @@ test('create a new database entry from model with timestamps', async t => {
     }
   });
 
-  const res = await put('PutCatTimestamp', { fromTest: 'put' });
+  const res = await put('PutCatTimestamp', { fromTest: 'put', meta: { age: 2 } });
   t.is(res.statusCode, 201, 'Status code is 201');
 
   const dbEntry = await CatModelTimestamps.findOne({ name: 'PutCatTimestamp' }).lean();
   t.true(dbEntry !== null, 'db entry exists');
   t.is(dbEntry.name, 'PutCatTimestamp', 'entry has right name');
+  t.is(dbEntry.meta.age, 2, 'entry has right meta');
 });
 
 test('update an existing database entry', async t => {


### PR DESCRIPTION
**Problem**:

The current put handler errors with the following message on a regular request to a simple hapi-forest put endpoint:
```
MongoError: the update operation document must contain atomic operators.
    at Function.create (/my/path/node_modules/mongodb-core/lib/error.js:43:12)
    at toError (/my/path/node_modules/mongodb/lib/utils.js:149:22)
    at checkForAtomicOperators (/my/path/node_modules/mongodb/lib/operations/collection_ops.js:161:12)
    at Collection.updateOne (/my/path/node_modules/mongodb/lib/collection.js:722:15)
    at NativeCollection.(anonymous function) [as updateOne] (/my/path/node_modules/mongoose/lib/drivers/node-mongodb-native/collection.js:146:28)
    at NodeCollection.updateOne (/my/path/node_modules/mquery/lib/collection/node.js:82:19)
    at model.Query._updateThunk (/my/path/node_modules/mongoose/lib/query.js:3450:23)
    at model.Query.Query._updateOne (/my/path/node_modules/mongoose/lib/query.js:3484:23)
    at /my/path/node_modules/kareem/index.js:278:20
    at _next (/my/path/node_modules/kareem/index.js:102:16)
    at process.nextTick (/my/path/node_modules/kareem/index.js:499:38)
    at process.internalTickCallback (internal/process/next_tick.js:70:11)
```
This is probably occurring since `mongoose` version `5.x`, which already is a peerDependency (`^5.2.9`). Unfortunately the devDependency entry was on `^4.7.2`, which prevented the tests from failing.

**Solution**:

I tried to bypassed this error by implementing a switch between `mongoose.updateOne` and `mongoose.replaceOne`, but this led to another issue: `mongoose.replaceOne` seems to ignore nested properties, so I got empty sub-documents and arrays with only `null` items.

My solution to avoid the above error now is to switch to `mongoose.update` with (implicit) `multi: true`.